### PR TITLE
fix: hits.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@
 
 
 
-![Hits](https://hits.link/hits?url=https://github.com/pxseu&label=views&bgRight=ff69b4)
+![Hits](https://hits-app.vercel.app/hits?url=https://github.com/pxseu&label=views&bgRight=ff69b4)
 
 


### PR DESCRIPTION
we've recently dropped the hits.link domain because the renewal price was $180, please use the updated/stable one :D!

sorry for the inconvenience!